### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/README-refs.bib
+++ b/README-refs.bib
@@ -1,6 +1,6 @@
 @inproceedings{benkeser2016hal,
   doi = {10.1109/dsaa.2016.93},
-  url = {https://dx.doi.org/10.1109/dsaa.2016.93},
+  url = {https://doi.org/10.1109/dsaa.2016.93},
   year  = {2016},
   publisher = {{IEEE}},
   author = {Benkeser, David and {van der Laan}, Mark J},
@@ -11,7 +11,7 @@
 
 @article{vdl2017generally,
   doi = {10.1515/ijb-2015-0097},
-  url = {https://dx.doi.org/10.1515/ijb-2015-0097},
+  url = {https://doi.org/10.1515/ijb-2015-0097},
   title = {A Generally Efficient Targeted Minimum Loss Based Estimator based on
     the {Highly Adaptive Lasso}},
   author = {{van der Laan}, Mark J},

--- a/README.Rmd
+++ b/README.Rmd
@@ -128,7 +128,7 @@ After using the `hal9001` R package, please cite the following:
           title = {{hal9001}: A fast and scalable {Highly Adaptive LASSO}},
           year  = {2018},
           howpublished = {\url{https://github.com/jeremyrcoyle/hal9001}},
-          url = {http://dx.doi.org/DOI_TBD},
+          url = {https://doi.org/DOI_TBD},
           doi = {DOI_TBD}
         }
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ After using the `hal9001` R package, please cite the following:
       title = {{hal9001}: A fast and scalable {Highly Adaptive LASSO}},
       year  = {2018},
       howpublished = {\url{https://github.com/jeremyrcoyle/hal9001}},
-      url = {http://dx.doi.org/DOI_TBD},
+      url = {https://doi.org/DOI_TBD},
       doi = {DOI_TBD}
     }
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -143,7 +143,7 @@ install.packages("hal9001")
       title = {{hal9001}: A fast and scalable {Highly Adaptive LASSO}},
       year  = {2017},
       howpublished = {\url{https://github.com/jeremyrcoyle/hal9001}},
-      url = {http://dx.doi.org/DOI_TBD},
+      url = {https://doi.org/DOI_TBD},
       doi = {DOI_TBD}
     }</code></pre>
 <hr></section><section id="license" class="level2"><h2>License</h2>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that I guess generates new ones.

Cheers!