### PR TITLE
return lasso fits upon request

### DIFF
--- a/R/hal.R
+++ b/R/hal.R
@@ -29,6 +29,8 @@
 #' @param family A \code{character} corresponding to the error family for a
 #'  generalized linear model. Options are limited to "gaussian" for fitting a
 #'  standard general linear model and "binomial" for logistic regression.
+#' @param return_lasso A \code{boolean} indicating whether or not to return
+#' the HAL lasso fit. 
 #' @param yolo A \code{logical} indicating whether to print one of a curated
 #'  selection of quotes from the HAL9000 computer, from the critically acclaimed
 #'  epic science-fiction film "2001: A Space Odyssey" (1968).
@@ -51,6 +53,7 @@ fit_hal <- function(X,
                     n_folds = 10,
                     use_min = TRUE,
                     family = c("gaussian", "binomial"),
+                    return_lasso = FALSE, 
                     ...,
                     yolo = TRUE) {
 
@@ -141,8 +144,12 @@ fit_hal <- function(X,
     coefs = coefs,
     times = times,
     lambda_star = lambda_star,
-    family = family
+    family = family,
+    hal_lasso = NULL
   )
+  if(return_model){
+    fit$hal_lasso <- hal_lasso
+  }
   class(fit) <- "hal9001"
   return(fit)
 }

--- a/R/hal.R
+++ b/R/hal.R
@@ -147,7 +147,7 @@ fit_hal <- function(X,
     family = family,
     hal_lasso = NULL
   )
-  if(return_model){
+  if(return_lasso){
     fit$hal_lasso <- hal_lasso
   }
   class(fit) <- "hal9001"

--- a/man/fit_hal.Rd
+++ b/man/fit_hal.Rd
@@ -5,8 +5,8 @@
 \title{HAL: The Highly Adaptive LASSO estimator}
 \usage{
 fit_hal(X, Y, degrees = NULL, fit_type = c("glmnet", "lassi"),
-  n_folds = 10, use_min = TRUE, family = c("gaussian", "binomial"), ...,
-  yolo = TRUE)
+  n_folds = 10, use_min = TRUE, family = c("gaussian", "binomial"),
+  return_lasso = FALSE, ..., yolo = TRUE)
 }
 \arguments{
 \item{X}{An input \code{matrix} containing observations and covariates
@@ -35,6 +35,9 @@ to \code{"lambda.1se"}.}
 \item{family}{A \code{character} corresponding to the error family for a
 generalized linear model. Options are limited to "gaussian" for fitting a
 standard general linear model and "binomial" for logistic regression.}
+
+\item{return_lasso}{A \code{boolean} indicating whether or not to return
+the HAL lasso fit.}
 
 \item{...}{Other arguments passed to \code{cv.glmnet}. Please consult the
 documentation for \code{glmnet} for a full list of options.}


### PR DESCRIPTION
In some situations, having the fitted object is useful. For example, @jucheng1992 and I are working on a HAL CTMLE project where we need HAL fits for different values of lambda. 

I have added an option to return the lasso fit, set by default to `FALSE`. 